### PR TITLE
Skip tests if lcpan is not available

### DIFF
--- a/lib/Dist/Zilla/Plugin/Prereqs/CheckCircular.pm
+++ b/lib/Dist/Zilla/Plugin/Prereqs/CheckCircular.pm
@@ -10,7 +10,7 @@ use warnings;
 use Moose;
 with 'Dist::Zilla::Role::InstallTool';
 
-use App::lcpan::Call qw(call_lcpan_script);
+use App::lcpan::Call qw(call_lcpan_script check_lcpan);
 use namespace::autoclean;
 
 sub _list_my_modules {
@@ -32,6 +32,13 @@ sub setup_installer {
     if ($ENV{DZIL_CHECKCIRCULAR_SKIP}) {
         $self->log(["Skipping checking circular dependency because ".
                         "environment DZIL_CHECKCIRCULAR_SKIP is set to true"]);
+        return;
+    }
+
+    my $lcpan_check = check_lcpan();
+    unless ($lcpan_check->[0] == 200) {
+        $self->log(["Skipping checking circular dependency because ".
+                        "lcpan_check was not successful: " . $lcpan_check->[1]]);
         return;
     }
 


### PR DESCRIPTION
The check for circular dependencies is done using `lcpan`, which in turns uses a local mirror of the CPAN database. For `lcpan` to work, the user needs to have run `lcpan update` after installation. But with a plugin like this, that installs `lcpan` automatically and without the user's knowledge, it is likely that new developers will miss that crucial step.

Prior to this patch, this caused the test suite to die with the following message: 

    Can't 'lcpan stats': 500 - Died: Can't find index '/home/user/cpan/index.db'

This is cryptic because it is not entirely clear how `lcpan` is connected to the test suite, nor why it is important, nor how this problem should be solved (there is no mention of eg. `lcpan update` in the error message).

This patch makes it easier for new developers to contribute by making this a non-fatal error. Since a missing local CPAN database means that checking for circular versions is impossible, the tests are skipped with a more informative message.

This also makes it possible to use the `LCPAN_MAX_AGE` environment variable to dynamically specify how old the local database should be allowed to be for testing.
